### PR TITLE
[Junie]: Next steps (optional)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
 outputs:
   branch_name:
     description: "Junie working branch"
-    value: ${{ steps.prepare.outputs.WORKING_BRANCH }}
+    value: ${{ steps.prepare.outputs.EJ_WORKING_BRANCH }}
 
 runs:
   using: "composite"
@@ -142,6 +142,6 @@ runs:
         curl -L \
           -X DELETE \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ steps.prepare.outputs.GITHUB_TOKEN }}" \
+          -H "Authorization: Bearer ${{ steps.prepare.outputs.EJ_AUTH_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           ${GITHUB_API_URL:-https://api.github.com}/installation/token


### PR DESCRIPTION
## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**
            
            It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
            We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).
            
            - 🔗 **Issue:** Fixes: #33         
            
            '### 📊 Junie Summary'
            ### GitHub Action Output Fixes
### What I changed
- Fixed mismatched output names between the composite action and the implementation.
- Updated the action output `branch_name` to correctly reference `EJ_WORKING_BRANCH` produced by the prepare step.
- Corrected the token revocation step to use the prepared output `EJ_AUTH_GITHUB_TOKEN` instead of a non-existent `GITHUB_TOKEN` output.

### Why it matters
- The composite action exposed an output `branch_name: ${{ steps.prepare.outputs.WORKING_BRANCH }}` that was never set by the code. The code emits `EJ_WORKING_BRANCH`. This prevented consumers from retrieving the working branch.
- The revoke-token step attempted to use `steps.prepare.outputs.GITHUB_TOKEN` which is never set; the actual output is `EJ_AUTH_GITHUB_TOKEN`. This could cause the cleanup step to fail or skip proper revocation.

### Files touched
- `action.yml`
- `outputs.branch_name.value` → `${{ steps.prepare.outputs.EJ_WORKING_BRANCH }}`
- Revoke step header `Authorization: Bearer ...` → now uses `${{ steps.prepare.outputs.EJ_AUTH_GITHUB_TOKEN }}`

### Notes / Caveats
- The `Install Bun` step checks `inputs.path_to_bun_executable` which is not defined under `inputs:`. It currently evaluates to empty and keeps the step running; if you intend to make this configurable, consider adding the missing input.
- The `Revoke app token` step condition references `steps.prepare.outputs.skipped_due_to_workflow_validation_mismatch`, which is not set anywhere. It will evaluate truthy for the `!= 'true'` comparison and still execute. If you prefer explicit control, export an output for that scenario in `token.ts`.

### Next steps (optional)
- If desired, I can add the missing `path_to_bun_executable` input and wire it to the condition, or remove the condition entirely if always installing Bun is acceptable.