### PR TITLE
[Junie]: No changes to inputs/outputs

### DIFF
--- a/src/github/junie/junie-inputs.ts
+++ b/src/github/junie/junie-inputs.ts
@@ -11,10 +11,12 @@ export async function prepareJunieInputs(
 ): Promise<JunieRunInputs> {
     const junieTask: JunieTask = {}
 
+    // If explicit prompt provided via inputs, prefer it
     if (context.inputs.prompt) {
         junieTask.textTask = {text: context.inputs.prompt}
     }
 
+    // Provide direct links for Junie to fetch additional context
     if ((isIssueCommentEvent(context) && !context.isPR) || isIssuesEvent(context)) {
         junieTask.gitHubIssue = {url: context.payload.issue.html_url}
     }
@@ -43,10 +45,35 @@ export async function prepareJunieInputs(
         junieTask.gitHubPullRequest = {url: context.payload.pull_request.html_url}
     }
 
+    // Derive a textual task for Junie from the triggering event when available
+    let derivedText = "";
+    try {
+        if (context.inputs.prompt) {
+            derivedText = context.inputs.prompt;
+        } else if (isIssuesEvent(context)) {
+            const title = context.payload.issue.title ?? "";
+            const body = context.payload.issue.body ?? "";
+            derivedText = [title, body].filter(Boolean).join("\n\n");
+        } else if (isIssueCommentEvent(context)) {
+            derivedText = context.payload.comment.body ?? "";
+        } else if (isPullRequestEvent(context)) {
+            const title = context.payload.pull_request.title ?? "";
+            const body = context.payload.pull_request.body ?? "";
+            derivedText = [title, body].filter(Boolean).join("\n\n");
+        } else if (isPullRequestReviewEvent(context)) {
+            derivedText = context.payload.review.body ?? "";
+        } else if (isPullRequestReviewCommentEvent(context)) {
+            derivedText = context.payload.comment.body ?? "";
+        }
+    } catch {
+        // Best-effort; keep empty if structure differs
+        derivedText = derivedText || "";
+    }
+
     return {
         junieIngrazzioToken: context.inputs.appToken,
         junieTask: junieTask,
-        junieTaskText: "" // If we create a prompt here
+        junieTaskText: derivedText // Provide Junie with explicit instructions when possible
     }
 }
 


### PR DESCRIPTION
## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**
            
            It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
            We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).
            
            - 🔗 **Issue:** Fixes: #35         
            
            '### 📊 Junie Summary'
            ### GitHub Issue Text Passing Fix
### What I changed
- Taught the action to pass the actual user request text (from the issue/comment/PR event) to Junie CLI.
- This enables tasks like “Create Hello World txt file” (issue #35) to be executed because Junie now receives explicit, human-readable instructions via `EJ_TASK_TEXT`.

### Key implementation details
- Edited `src/github/junie/junie-inputs.ts`:
- Derive `junieTaskText` from the triggering event content:
- Issues → title + body
- Issue comments → comment body
- PRs → title + body
- PR reviews / review comments → respective body
- Preserve `inputs.prompt` behavior (if provided, it takes precedence and is also used as `junieTaskText`).
- Existing linkage fields (`gitHubIssue`, `gitHubPullRequest`, etc.) are still set so Junie can fetch extra context.

### Why this fixes #35
Previously `junieTaskText` was always empty, so Junie CLI lacked direct instructions. With the issue’s text now provided, Junie can perform the requested action (e.g., create a `Hello World` text file) and the subsequent commit/PR steps in the composite action will work as designed.

### Notes for verification
- Trigger the action by creating/updating issue #35 (or a similar test issue) with the instruction (e.g., “Create Hello World txt file”). Ensure the trigger phrase/labels match your action conditions, or provide `prompt` input explicitly.
- The action will:
1) Prepare and set up the working branch,
2) Run Junie CLI with both the GitHub URL context and the `junieTaskText` derived from the issue text,
3) Commit or open a PR according to the configured conditions.

### No changes to inputs/outputs
- All existing inputs in `action.yml` are unchanged. The fix is internal and backward-compatible.