### PR TITLE
[Junie]: Fix GitHub Action Issue #37

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -27,6 +27,8 @@ async function createNewBranch(baseBranch: string, branchName: string) {
         console.log(`Creating new branch ${newBranch}`);
         await $`git fetch origin ${baseBranch} --depth=1`;
         await $`git checkout ${baseBranch}`;
+        // Create and switch to the working branch from the base
+        await $`git checkout -b ${newBranch}`;
 
         console.log(`Successfully created and checked out new branch: ${newBranch}`);
 


### PR DESCRIPTION
## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**
            
It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).
            
- 🔗 **Issue:** Fixes: #37         
            
'### 📊 Junie Summary'
### Fix for Branch Creation Bug
### Summary
- Investigated the action to handle GitHub issue #37 (Oct 28, 2025 11:36 local) where a task like “@junie create txt file” should trigger Junie to create changes on a working branch and open a PR or commit directly.
- Found a defect in `src/github/operations/branch.ts`: the code path intended to create a new working branch never actually created it. It fetched and checked out the base branch but did not run `git checkout -b <new_branch>`.
- Implemented a fix to create and switch to the working branch properly.

### What changed
- File: `src/github/operations/branch.ts`
  - In `createNewBranch(...)` added the missing `git checkout -b ${newBranch}` after checking out the base branch so that a new branch is actually created and made current.

### Why this fixes the issue
- Without creating the working branch, subsequent steps (Junie edits and the create-pull-request or add-and-commit actions) operate on the base branch or fail to find the intended branch, preventing the expected file creation/PR. Now the workflow will:
  1) detect the trigger in the issue title/body/comment,
  2) prepare Junie inputs, and
  3) create a real working branch (e.g., `junie/issue-37`), enabling Junie to apply changes and the workflow to commit/push and either open a PR or commit directly.

### Notes
- No other behavior was altered. The PR creation conditions remain the same: when the working branch differs from the base branch, a PR will be created; otherwise, it will commit directly using the configured step.
- If desired, we can also smoke test the `prepare` entrypoint in CI with a lightweight dry-run matrix to validate branch creation, but the core fix is in place.